### PR TITLE
use a fast tree DFS to enumerate the leaves

### DIFF
--- a/src/id.mjs
+++ b/src/id.mjs
@@ -54,7 +54,7 @@ export function toDigest(value) {
   const copy = canonicalize({ ...value });
   const canonical = encode(copy);
   const digest = toHex(keccak256(canonical));
-  const index = `${value.timestamp.toString(16)}${digest}`;
+  const index = `${value.timestamp.toString(16).padStart(8, "0")}${digest}`;
   return {
     digest,
     canonical,

--- a/test/store_test.mjs
+++ b/test/store_test.mjs
@@ -38,34 +38,59 @@ test("if message passes constraint", async (t) => {
   await rm("dbtestA", { recursive: true });
 });
 
+test("returns leaves in ascending key order, small set", async (t) => {
+  env.DATA_DIR = "dbtestA";
+  const trieA = await store.create();
+  await trieA.put(Buffer.from("0c", "hex"), encode({ num: 0xc }));
+  await trieA.put(Buffer.from("05", "hex"), encode({ num: 0x5 }));
+  await trieA.put(Buffer.from("0a", "hex"), encode({ num: 0xa }));
+
+  const leaves = await store.leaves(trieA);
+  t.is(leaves.length, 3);
+  t.deepEqual([{ num: 0x5 }, { num: 0xa }, { num: 0xc }], leaves);
+
+  await rm("dbtestA", { recursive: true });
+});
+
+test("returns leaves in ascending key order, large set", async (t) => {
+  env.DATA_DIR = "dbtestA";
+  const trieA = await store.create();
+
+  const minTimestamp = 1681486433; // "Kiwistand is live" story submitted
+  const timestamps = Array.from(
+    { length: 100 },
+    (_, i) => minTimestamp + 82800 * i
+  );
+
+  for (const timestamp of [...timestamps].sort(() => Math.random() - 0.5)) {
+    await trieA.put(
+      Buffer.from(timestamp.toString(16).padStart(8, "0"), "hex"),
+      encode({ timestamp })
+    );
+  }
+
+  const leaves = await store.leaves(trieA);
+  t.is(leaves.length, timestamps.length);
+  t.deepEqual(
+    timestamps.map((timestamp) => ({ timestamp })),
+    leaves
+  );
+
+  await rm("dbtestA", { recursive: true });
+});
+
 test("amount limiting factor", async (t) => {
   env.DATA_DIR = "dbtestA";
   const trieA = await store.create();
-  await trieA.put(Buffer.from("0101", "hex"), encode({ num: 0 }));
-  await trieA.put(Buffer.from("1010", "hex"), encode({ num: 1 }));
-  await trieA.put(Buffer.from("1100", "hex"), encode({ num: 2 }));
+  await trieA.put(Buffer.from("0c", "hex"), encode({ num: 0xc }));
+  await trieA.put(Buffer.from("05", "hex"), encode({ num: 0x5 }));
+  await trieA.put(Buffer.from("0a", "hex"), encode({ num: 0xa }));
 
   const from = 0;
   const amount = 2;
   const leaves = await store.leaves(trieA, from, amount);
   t.is(leaves.length, 2);
-  t.deepEqual([{ num: 0 }, { num: 1 }], leaves);
-
-  await rm("dbtestA", { recursive: true });
-});
-
-test("getting more paginated leaves than exist but only return existing", async (t) => {
-  env.DATA_DIR = "dbtestA";
-  const trieA = await store.create();
-  await trieA.put(Buffer.from("0101", "hex"), encode({ num: 0 }));
-  await trieA.put(Buffer.from("1010", "hex"), encode({ num: 1 }));
-  await trieA.put(Buffer.from("1100", "hex"), encode({ num: 2 }));
-
-  const from = 1;
-  const amount = 50;
-  const leaves = await store.leaves(trieA, from, amount);
-  t.is(leaves.length, 2);
-  t.deepEqual([{ num: 1 }, { num: 2 }], leaves);
+  t.deepEqual([{ num: 0x5 }, { num: 0xa }], leaves);
 
   await rm("dbtestA", { recursive: true });
 });
@@ -73,15 +98,31 @@ test("getting more paginated leaves than exist but only return existing", async 
 test("getting paginated leaves", async (t) => {
   env.DATA_DIR = "dbtestA";
   const trieA = await store.create();
-  await trieA.put(Buffer.from("0101", "hex"), encode({ num: 0 }));
-  await trieA.put(Buffer.from("1010", "hex"), encode({ num: 1 }));
-  await trieA.put(Buffer.from("1100", "hex"), encode({ num: 2 }));
+  await trieA.put(Buffer.from("0c", "hex"), encode({ num: 0xc }));
+  await trieA.put(Buffer.from("05", "hex"), encode({ num: 0x5 }));
+  await trieA.put(Buffer.from("0a", "hex"), encode({ num: 0xa }));
 
   const from = 1;
   const amount = 2;
   const leaves = await store.leaves(trieA, from, amount);
   t.is(leaves.length, amount);
-  t.deepEqual([{ num: 1 }, { num: 2 }], leaves);
+  t.deepEqual([{ num: 0xa }, { num: 0xc }], leaves);
+
+  await rm("dbtestA", { recursive: true });
+});
+
+test("getting more paginated leaves than exist but only return existing", async (t) => {
+  env.DATA_DIR = "dbtestA";
+  const trieA = await store.create();
+  await trieA.put(Buffer.from("0c", "hex"), encode({ num: 0xc }));
+  await trieA.put(Buffer.from("05", "hex"), encode({ num: 0x5 }));
+  await trieA.put(Buffer.from("0a", "hex"), encode({ num: 0xa }));
+
+  const from = 1;
+  const amount = 50;
+  const leaves = await store.leaves(trieA, from, amount);
+  t.is(leaves.length, 2);
+  t.deepEqual([{ num: 0xa }, { num: 0xc }], leaves);
 
   await rm("dbtestA", { recursive: true });
 });


### PR DESCRIPTION
This PR implements a DFS trie walk as a generator.

Benefits:
- Messages are returned in ascending key order — so they're in ascending timestamp order.
- Faster by about a third when iterating through the whole message set.
- Can bail on iteration when done.

Benchmarks on 1000 runs for old and new walker (not accounting for message ordering time):

```
[0] posts-oo4r3t-{"from":null,"amount":null,"startDateTime":null}-new way: 25.166s
[0] posts-oo4r3t-{"from":null,"amount":null,"startDateTime":null}-old way: 36.618s

[0] posts-i0b6ni-{"from":0,"amount":500,"startDateTime":null}-new way: 5.239s
[0] posts-i0b6ni-{"from":0,"amount":500,"startDateTime":null}-old way: 23.746s

[0] posts-2ym77v-{"from":1000,"amount":500,"startDateTime":null}-new way: 13.996s
[0] posts-2ym77v-{"from":1000,"amount":500,"startDateTime":null}-old way: 30.884s

[0] posts-8xq9vn-{"from":2000,"amount":500,"startDateTime":null}-new way: 23.039s
[0] posts-8xq9vn-{"from":2000,"amount":500,"startDateTime":null}-old way: 34.398s
```

I haven't had a chance to test `startDateTime` — and I think we can improve performance even more if we control traversal/select branches which we want to descend.