### PR TITLE
Made Settings page more noob-friendly

### DIFF
--- a/src/views/settings.mjs
+++ b/src/views/settings.mjs
@@ -31,29 +31,16 @@ export default function index(theme) {
                   <p
                     style="color: black; padding: 7px 7px 15px 7px; font-size: 12pt;"
                   >
-                    From now on you can submit and upvote links without
-                    confirming them in your wallet.
+                    You can turn on “Signless Kiwi Experience” to submit and upvote stories without needing to sign every action. You can set it up on your mobile and desktop.
                     <br />
                     <br />
-                    Thanks to that using Kiwi is going to feel like using
-                    Warpcast or a web2 app. You just need to click the button
-                    below and delegate posting authority. It's safe and works
-                    like magic.
-                    <br />
-                    <br />
-                    If you want to learn how it works under the hood, check
-                    <a
-                      href="https://www.loom.com/share/244e444db3444cc3b50376d38e72bd69"
-                      target="_blank"
-                      >Tim's Loom video.</a
-                    >
-                    <br />
-                    <br />
-                    PS: Don’t worry if you have enough ETH on Optimism - we
-                    airdropped you some so you can do it easily.
+                    After you click "Turn on", it might take up to 5 minutes to make it work. If you'd like to learn how it works check <u><a href="https://www.loom.com/share/244e444db3444cc3b50376d38e72bd69" target="_blank">Tim's Loom video</a></u>.
                     <br />
                     <br />
                     <delegate-button />
+                    <br />
+                    <br />
+                    
                   </p>
                 </td>
               </tr>

--- a/src/web/src/DelegateButton.jsx
+++ b/src/web/src/DelegateButton.jsx
@@ -125,52 +125,24 @@ const DelegateButton = () => {
   }
 
   if (!from.address) return <b>Please connect your wallet</b>;
+
   if (key && wallet) {
-    const disabled = confirmation !== "delete key";
     return (
       <div>
-        <p>
-          <b>You're set!</b>
-        </p>
-        <p>
-          We've now stored your delegation key on Optimism for this device. You
-          should be able to upvote and submit links without needing to confirm
-          these actions in your wallet!
-        </p>
-        <p>
-          <b>PLEASE NOTE: </b>
-          It might take up to 5 minutes for your key to enter the system!
-        </p>
-        <p>
-          <b>Key storage</b>
-        </p>
-        <p style={{ wordBreak: "break-all" }}>
-          Your delegate address: {wallet.address}
-        </p>
-        <p>
-          <b>Delete key</b>
-          <p>
-            You can delete your key from the browser, however, please consider
-            that you'll not be able to recover it. Please type <b>delete key</b>{" "}
-            to confirm.
-          </p>
-          <input
-            type="text"
-            value={confirmation}
-            onChange={(e) => setConfirmation(e.target.value)}
-          />
-          <br />
-          <br />
-          <button
-            className="buy-button"
-            disabled={disabled}
-            onClick={handleClick}
-          >
-            Delete key
-          </button>
-        </p>
+        <button
+          className="buy-button"
+          onClick={handleClick} // Assuming handleClick is the function that deletes the key
+        >
+          Turn off
+        </button>
+        <br/>
+        <br/>
+       <p style={{ margin: '0', padding: '0' }}>
+        You can now upvote and submit stories without signing each action! Please remember that if you clean your browser’s cookies, you might have to turn it on again.
+      </p>
       </div>
     );
+  
   }
   if (!write && !isError) {
     return <p>Loading from local storage...</p>;
@@ -181,7 +153,7 @@ const DelegateButton = () => {
   if (chain.id === 10) {
     content = (
       <span>
-        {!isLoading && !isSuccess && <div>Delegate on Optimism</div>}
+        {!isLoading && !isSuccess && <div>Turn On</div>}
         {isLoading && <div>Please sign transaction</div>}
         {isSuccess && <div>Delegation successful, please reload</div>}
       </span>


### PR DESCRIPTION
I thought that the word delegation, showing delegated keys (that are not your wallet keys) etc. might have been too much for new users. So I just hid all tech details and left them in your Loom video link.