### PR TITLE
feat: add the total tips a user received on the home page

### DIFF
--- a/src/tips.mjs
+++ b/src/tips.mjs
@@ -10,13 +10,14 @@ const fetch = fetchBuilder.withCache(
   }),
 );
 
-const TIP_GET_ENDPOINT = "https://getusertips-zl7caqyemq-uc.a.run.app?user=";
+const USER_TIP_GET_ENDPOINT = "https://getusertips-zl7caqyemq-uc.a.run.app?user=";
+const TOTAL_TIP_GET_ENDPOINT = "https://gettips-zl7caqyemq-uc.a.run.app";
 const TIP_API_KEY = "73yZ9m4JJccccsm0L6HNPanQm";
 
-export async function getTips(address) {
+export async function getUserTips(address) {
   try {
     // 1. Fetch tips from the API
-    const response = await fetch(`${TIP_GET_ENDPOINT}${address}`, {
+    const response = await fetch(`${USER_TIP_GET_ENDPOINT}${address}`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${TIP_API_KEY}`,
@@ -42,6 +43,32 @@ export async function getTips(address) {
       index: metadata.index,
       title: metadata.title,
     }));
+  } catch (error) {
+    console.error("Fetching tips failed:", error);
+    return [];
+  }
+}
+
+export async function getTips() {
+  try {
+    // 1. Fetch tips from the API
+    const response = await fetch(`${TOTAL_TIP_GET_ENDPOINT}`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TIP_API_KEY}`,
+      },
+    });
+
+    // 2. Get the data from the response
+    const data = await response.json();
+
+    // 3. Check if the response is valid
+    if (!data || !data.success || !data.data) {
+      return [];
+    }
+
+    const receiver = data.data.receivers;
+    return receiver ? receiver : 0;
   } catch (error) {
     console.error("Fetching tips failed:", error);
     return [];

--- a/src/views/activity.mjs
+++ b/src/views/activity.mjs
@@ -18,7 +18,7 @@ import * as registry from "../chainstate/registry.mjs";
 import * as id from "../id.mjs";
 import * as moderation from "./moderation.mjs";
 import cache from "../cache.mjs";
-import { getTips } from "../tips.mjs";
+import { getUserTips } from "../tips.mjs";
 
 const html = htm.bind(vhtml);
 
@@ -257,7 +257,7 @@ export async function data(trie, identity, lastRemoteValue) {
   );
   leaves = moderation.moderate(leaves, config);
 
-  let tips = await getTips(identity);
+  let tips = await getUserTips(identity);
 
   const activities = generateFeed(leaves);
   const filteredActivities = activities.filter(

--- a/src/views/components/row.mjs
+++ b/src/views/components/row.mjs
@@ -186,6 +186,7 @@ const row = (
                           data-address="${story.identity}"
                           data-index="${story.index}"
                           data-title="${story.title}"
+                          data-tip="${story.tipValue}"
                         >
                         </span>
                       `}

--- a/src/views/feed.mjs
+++ b/src/views/feed.mjs
@@ -6,6 +6,7 @@ import htm from "htm";
 import vhtml from "vhtml";
 import normalizeUrl from "normalize-url";
 import { sub, differenceInMinutes, isBefore } from "date-fns";
+import { getTips } from "../tips.mjs";
 
 import * as ens from "../ens.mjs";
 import Header from "./components/header.mjs";
@@ -279,8 +280,20 @@ export async function index(trie, page, domain) {
   }
 
   let stories = [];
+
+  // 1. Fetch tips from the API
+  let tips = await getTips();
+  
   for await (let story of storyPromises) {
     const ensData = await ens.resolve(story.identity);
+
+    // 1. Get the tips for the story submitter
+    let userTips = tips[story.identity.toLowerCase()]
+    // 2. Get the total value of the tips, if any
+    const tipValue = userTips ? userTips.totalValue : 0;
+    // 3. Add the total value to the tipValue property of the story
+    story.tipValue = tipValue;
+
     let avatars = [];
     for await (let upvoter of story.upvoters) {
       const profile = await ens.resolve(upvoter);

--- a/src/web/src/Tip.jsx
+++ b/src/web/src/Tip.jsx
@@ -22,7 +22,7 @@ const Tip = (props) => {
     <span>
       <span> • </span>
       <a onClick={handlePayClick} className="caster-link">
-        $ Tip
+        $ Tip {props.totalValue > 0 ? `($${parseFloat(props.tipValue).toFixed(2)} received)` : "(Be the first to tip)"}
       </a>
     </span>
   );

--- a/src/web/src/main.jsx
+++ b/src/web/src/main.jsx
@@ -72,6 +72,7 @@ async function addTips() {
       const address = tip.getAttribute("data-address");
       const index = tip.getAttribute("data-index");
       const title = tip.getAttribute("data-title");
+      const tipValue = tip.getAttribute("data-tip");
 
       const metadata = {
         index: index,
@@ -80,7 +81,7 @@ async function addTips() {
 
       createRoot(tip).render(
         <StrictMode>
-          <Tip address={address} metadata={metadata} />
+          <Tip address={address} metadata={metadata} tipValue={tipValue} />
         </StrictMode>,
       );
     });


### PR DESCRIPTION
## Description
It adds the total value of tips received by a story submitter next to each story. To avoid making a request for each story, we initially fetch the total tips that have been made and then filter these tips by address for each story.

If tip exists, we display the button as: 
- $ Tip ($1.70 received)

If tip doesn't exist, the CTA button is: 
- $ Tip (Be the first to tip)

## Screenshot
If the story submitter has already received tips:
<img width="672" alt="Screenshot 2023-12-16 at 8 54 48 AM" src="https://github.com/attestate/kiwistand/assets/5286353/8d3bf517-f9f8-4dbe-881a-2d4877e6069f">
If the story submitter hasn't receive any:
<img width="638" alt="Screenshot 2023-12-16 at 8 55 06 AM" src="https://github.com/attestate/kiwistand/assets/5286353/5f8ffb42-1f8d-4fb7-a318-8a168ae64b67">
