### PR TITLE
fix: display the total tipped amount made to a story

### DIFF
--- a/src/tips.mjs
+++ b/src/tips.mjs
@@ -11,7 +11,7 @@ const fetch = fetchBuilder.withCache(
 );
 
 const USER_TIP_GET_ENDPOINT = "https://getusertips-zl7caqyemq-uc.a.run.app?user=";
-const TOTAL_TIP_GET_ENDPOINT = "https://gettips-zl7caqyemq-uc.a.run.app";
+const TOTAL_TIP_GET_ENDPOINT = "https://getalldapppayments-zl7caqyemq-uc.a.run.app?dapp=kiwi";
 const TIP_API_KEY = "73yZ9m4JJccccsm0L6HNPanQm";
 
 export async function getUserTips(address) {
@@ -49,6 +49,20 @@ export async function getUserTips(address) {
   }
 }
 
+export function getTipsValue(tips, storyIndex) {
+  // 1. Retrieve all items from data that have the same index as the storyIndex
+  const filteredTips = tips.filter((tip) => {
+    if (!tip.metadata) {
+      return false;
+    }
+    const metadata = JSON.parse(tip.metadata);
+    return metadata.index === storyIndex;
+  });
+
+  // 2. Sum all usdAmounts from the filteredTips
+  return filteredTips.reduce((total, tip) => total + tip.usdAmount, 0);
+}
+
 export async function getTips() {
   try {
     // 1. Fetch tips from the API
@@ -67,8 +81,7 @@ export async function getTips() {
       return [];
     }
 
-    const receiver = data.data.receivers;
-    return receiver ? receiver : 0;
+    return data.data;
   } catch (error) {
     console.error("Fetching tips failed:", error);
     return [];

--- a/src/views/feed.mjs
+++ b/src/views/feed.mjs
@@ -6,7 +6,7 @@ import htm from "htm";
 import vhtml from "vhtml";
 import normalizeUrl from "normalize-url";
 import { sub, differenceInMinutes, isBefore } from "date-fns";
-import { getTips } from "../tips.mjs";
+import { getTips, getTipsValue } from "../tips.mjs";
 
 import * as ens from "../ens.mjs";
 import Header from "./components/header.mjs";
@@ -287,11 +287,8 @@ export async function index(trie, page, domain) {
   for await (let story of storyPromises) {
     const ensData = await ens.resolve(story.identity);
 
-    // 1. Get the tips for the story submitter
-    let userTips = tips[story.identity.toLowerCase()]
-    // 2. Get the total value of the tips, if any
-    const tipValue = userTips ? userTips.totalValue : 0;
-    // 3. Add the total value to the tipValue property of the story
+    // 1. Add the total value to the tipValue property of the story
+    const tipValue = getTipsValue(tips, story.index);
     story.tipValue = tipValue;
 
     let avatars = [];

--- a/src/web/npm-shrinkwrap.json
+++ b/src/web/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@attestate/delegator2": "0.1.2",
-        "@dawnpay/kit": "0.0.6",
+        "@dawnpay/kit": "0.0.9",
         "@ethersproject/units": "5.7.0",
         "@ethersproject/wallet": "5.7.0",
         "@rainbow-me/rainbowkit": "0.12.15",
@@ -93,11 +93,11 @@
       }
     },
     "node_modules/@dawnpay/kit": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@dawnpay/kit/-/kit-0.0.6.tgz",
-      "integrity": "sha512-I6cFeBz2d4egXIHyDfqoBOYyjuSQi5G3c6JTLNy4r4VLgl81Lj1pP7T3MJQhNTju4f+QARqpCd3rSGUnivKDDQ==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@dawnpay/kit/-/kit-0.0.9.tgz",
+      "integrity": "sha512-gvV5obzumMjBmh+kTjcM3b9MjEb1oYuEJH4Kkz0lUrPLb851L5qCum7GRYqr7UCsVbSsx5ey90IujBYZYpqesw==",
       "dependencies": {
-        "@dawnpay/sdk": "^0.0.7",
+        "@dawnpay/sdk": "0.0.9",
         "@mui/material": "^5.14.18",
         "@radix-ui/react-dialog": "^1.0.5",
         "@types/node": "^20.8.10",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@dawnpay/sdk": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@dawnpay/sdk/-/sdk-0.0.7.tgz",
-      "integrity": "sha512-2MUYbkQbBz9Jnd7gSv55q3cwnZcmFwYD0VgTYKpGpm7oWVvtZhp5M+LL23fU1dASW4w1m3nQbMNgXlnFaTYoWA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@dawnpay/sdk/-/sdk-0.0.9.tgz",
+      "integrity": "sha512-67mGdDC3QbcHR/rJ4QDraSpSS86w00y9VCHHcLeiRCSzaKIs3sfNs0LDmH+yrUciP4m2T0aafwdJQ7vgZZ+ydg==",
       "dependencies": {
         "@types/node": "^20.8.10",
         "ethers": "^6.8.1",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@dawnpay/kit": "0.0.6",
+    "@dawnpay/kit": "0.0.9",
     "@attestate/delegator2": "0.1.2",
     "@ethersproject/units": "5.7.0",
     "@ethersproject/wallet": "5.7.0",


### PR DESCRIPTION
## Description
Previously, the total tipped amount was the amount received by an address, not the story. This PR filters out the tips made to a story and sums up all the USD amounts.

## Screenshot
<img width="680" alt="Screenshot 2023-12-19 at 10 14 08 AM" src="https://github.com/attestate/kiwistand/assets/5286353/c8716d74-96d4-43e7-8a29-cc9248391bf9">
