### PR TITLE
Row UI: accents, better mobile

### DIFF
--- a/src/views/components/row.mjs
+++ b/src/views/components/row.mjs
@@ -142,7 +142,9 @@ const row = (
                   >
                 </span>
                 <div style="font-size: 10pt;">
-                  <span>
+                  <span 
+                    style="display: flex; flex-wrap: wrap; gap: 0.3em; opacity:0.5;"
+                  >
                     ${path !== "/stories" &&
                     story.avatars.length > 3 &&
                     html`
@@ -164,7 +166,7 @@ const row = (
                             `,
                           )}
                         </div>
-                        <span> • </span>
+                        <span style="opacity:0.3"> • </span>
                       </span>
                     `}
                     ${story.index
@@ -202,10 +204,11 @@ const row = (
                           ${story.displayName}
                         </a>`
                       : story.displayName}
+                      <span class="row-actions" role="actions">
                     ${interactive || hideCast || !story.index
                       ? null
                       : html`
-                          <span> • </span>
+                          <span style="opacity:0.3"> • </span>
                           <a
                             target="_blank"
                             href="https://warpcast.com/~/compose?embeds[]=${encodeURIComponent(
@@ -223,7 +226,7 @@ const row = (
                       ? null
                       : html`
                           <span class="share-container">
-                            <span> • </span>
+                            <span style="opacity:0.3"> • </span>
                             <a
                               href="#"
                               class="caster-link share-link"
@@ -242,7 +245,7 @@ const row = (
                       ? null
                       : html`
                           <span class="inverse-share-container">
-                            <span> • </span>
+                            <span style="opacity:0.3"> • </span>
                             <a
                               href="#"
                               class="meta-link share-link"
@@ -257,6 +260,7 @@ const row = (
                             </a>
                           </span>
                         `}
+                    </span>
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
Played with readability. 
On mobile cast+share in 80% are broken in 2 lines in an unconsistent way -> changed so they break to the next line together. Now ui is more predictable on mobile an eyepath is cleaner. 

Before:
<img width="266" alt="image" src="https://github.com/attestate/kiwistand/assets/6696080/28bae1d0-09d7-452d-b311-204139e2b428">

After:
<img width="255" alt="image" src="https://github.com/attestate/kiwistand/assets/6696080/890e9dc2-e149-4937-8c9e-b73d3a8bdb1c">
