### PR TITLE
Update ecosystem2.config.js for cluster mode

### DIFF
--- a/ecosystem2.config.js
+++ b/ecosystem2.config.js
@@ -4,10 +4,12 @@ module.exports = {
   apps: [
     {
       name: "kiwinews",
-      script: "npm run start",
+      script: "./src/launch.mjs",
+      // max_memory_restart: "XXXXM", enable to let pm2 restart the app when reaching the memory limit
       env: {
         DEBUG: "*attestate*",
         NODE_ENV: "production",
+        NODE_PATH: "./node_modules",
         THEME: "kiwi",
         HTTP_PORT: 3000,
         API_PORT: 8443,
@@ -17,7 +19,7 @@ module.exports = {
         USE_EPHEMERAL_ID: false,
       },
       time: true,
-      node_args: "--max-old-space-size=12288",
+      node_args: "-r dotenv/config --max-old-space-size=12288",
     },
   ],
 };


### PR DESCRIPTION
Enables pm2 to have direct access to the app and to control it better than before.

Using npm to start the app caused pm2 to fork it, and therefore pm2 had only control over the npm process, but not the kiwi app itself. To get rid of npm:

- replace the npm call with the script  ```script: "./src/launch.mjs" ```
- add the npm modules to the node path ```NODE_PATH: "./node_modules"```
- add the -r switch to node_args ```node_args: "-r dotenv/config --max-old-space-size=XXXX"```

Since cluster mode can scale the app, it is important to add ```instances: 1``` to disable scaling.
Another advantage of this approach is, that we now can use ``` max_memory_restart: "XXXXM"``` to tell pm2 to restart the app when the memory limits are reached. 