### PR TITLE
allow 7702-enabled EOAs

### DIFF
--- a/src/web/src/BuyButton.jsx
+++ b/src/web/src/BuyButton.jsx
@@ -36,7 +36,7 @@ export async function prepare(key) {
 
   const provider = getProvider();
   const code = await provider.getCode(address);
-  if (code !== "0x") throw new Error("Smart accounts aren't supported");
+  if (code && code !== "0x" && !code.startsWith("0xef0100")) throw new Error("Smart accounts aren't supported");
 
   const balance = {
     optimism: (await fetchBalance({ address, chainId: optimism.id })).value,


### PR DESCRIPTION
Currently 7702-enabled EOAs can't mint Kiwi passes. This checks for the 7702-prefix, to allow these EOAs to mint ([EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md))