### PR TITLE
Add story domain to OG preview images

### DIFF
--- a/src/preview.mjs
+++ b/src/preview.mjs
@@ -76,7 +76,7 @@ export function cfTransform(url, size) {
 }
 
 const emojiMatcher = emojiRegex();
-export function story(title, displayName, avatar) {
+export function story(title, displayName, avatar, domain) {
   title = title.replace(emojiMatcher, "");
   return html`
     <div
@@ -106,10 +106,24 @@ export function story(title, displayName, avatar) {
       >
         ${title}
       </p>
+      ${domain
+        ? html`
+            <p
+              style=${{
+                fontSize: "1.8rem",
+                margin: "0.5rem 0 0 0",
+                opacity: 0.7,
+              }}
+            >
+              ${domain}
+            </p>
+          `
+        : null}
       <p
         style=${{
           fontSize: "2rem",
           marginBottom: 0,
+          marginTop: domain ? "1rem" : 0,
         }}
       >
         submitted by
@@ -160,7 +174,7 @@ export function story(title, displayName, avatar) {
   `;
 }
 
-export function storyFrame(title, displayName, avatar) {
+export function storyFrame(title, displayName, avatar, domain) {
   title = title.replace(emojiMatcher, "");
   return html`
     <div
@@ -191,6 +205,20 @@ export function storyFrame(title, displayName, avatar) {
       >
         ${title}
       </p>
+      ${domain
+        ? html`
+            <p
+              style=${{
+                fontSize: "1.5rem",
+                margin: "-0.5rem 0 1rem 0",
+                opacity: 0.7,
+                textAlign: "center",
+              }}
+            >
+              ${domain}
+            </p>
+          `
+        : null}
       <div
         style=${{
           display: "flex",

--- a/src/views/story.mjs
+++ b/src/views/story.mjs
@@ -81,16 +81,18 @@ export async function generatePreview(index) {
     submitter: ensData,
   };
   const hexIndex = index.substring(2);
+  const domain = extractDomain(submission.href);
   try {
     const body = preview.story(
       value.title,
       value.submitter.displayName,
       value.submitter.safeAvatar,
+      domain,
     );
     await preview.generate(hexIndex, body); // Generate OG image (1200x630)
     await preview.generate(hexIndex, body, true); // Generate frame image (1200x800)
   } catch (err) {
-    const body = preview.story(value.title, value.submitter.displayName);
+    const body = preview.story(value.title, value.submitter.displayName, null, domain);
     await preview.generate(hexIndex, body); // Generate OG image (1200x630)
     await preview.generate(hexIndex, body, true); // Generate frame image (1200x800)
   }
@@ -183,16 +185,18 @@ export default async function (trie, theme, index, value, referral) {
   // Ensure frame preview exists for Farcaster embeds (after ENS resolution)
   if (!isCloudflareImage(value.href)) {
     const hexIndex = index.substring(2);
+    const domain = extractDomain(value.href);
     try {
       const body = preview.story(
         value.title,
         story.submitter.displayName,
         story.submitter.safeAvatar,
+        domain,
       );
       await preview.generate(hexIndex, body, true); // Generate frame version if missing
     } catch (err) {
       // Fallback without avatar if there's an error
-      const body = preview.story(value.title, story.submitter.displayName);
+      const body = preview.story(value.title, story.submitter.displayName, null, domain);
       await preview.generate(hexIndex, body, true);
     }
   }


### PR DESCRIPTION
Display the source domain below the title in both regular and frame preview images to help users identify content sources at a glance.

🤖 Generated with [Claude Code](https://claude.ai/code)