### PR TITLE
Fix mobile comment composer textarea overflow

### DIFF
--- a/src/web/src/CommentInput.jsx
+++ b/src/web/src/CommentInput.jsx
@@ -257,6 +257,7 @@ const MobileComposer = ({
           outline: "none",
           width: "100%",
           height: "100%",
+          boxSizing: "border-box",
           overflowY: "auto",
           touchAction: "auto",
           backgroundColor: "var(--bg-white)",


### PR DESCRIPTION
The textarea inside MobileComposer uses width:100% plus padding:1rem.
Without box-sizing:border-box that totals viewport width + 2rem,
pushing content past the right edge on mobile.

This only started overflowing after commit 751e4b7 added <!DOCTYPE html>
to the story/feed templates. Without the doctype the pages rendered in
quirks mode where WebKit's default textarea box sizing absorbed the
padding; with standards mode it now follows content-box and overflows.

Add boxSizing:"border-box" so the padding is included in the 100% width.