### PR TITLE
Match client comment text size to server-rendered

### DIFF
--- a/src/web/src/CommentSection.jsx
+++ b/src/web/src/CommentSection.jsx
@@ -801,7 +801,7 @@ const Comment = React.forwardRef(
           display: "block",
           marginBottom: isLastComment ? "28px" : "12px",
           whiteSpace: "pre-wrap",
-          lineHeight: "1.2",
+          lineHeight: "1.3",
           wordBreak: "break-word",
           overflowWrap: "break-word",
           transition: "all 0.2s ease",
@@ -882,10 +882,7 @@ const Comment = React.forwardRef(
             </div>
             {!isCollapsed && (
               <>
-                <span
-                  className="comment-text"
-                  style={{ fontSize: "11pt", lineHeight: "1.15" }}
-                >
+                <span className="comment-text">
                   <Linkify
                     options={{
                       className: "meta-link selectable-link",


### PR DESCRIPTION
Client-rendered comments set fontSize: 11pt and lineHeight: 1.15 on
.comment-text, while server-rendered comments inherit 1rem from the
parent with line-height: 1.3 on the wrapper. This caused newly posted
comments to appear smaller until a page refresh re-rendered them
server-side. Align the client to the server by dropping the fontSize
override and using lineHeight: 1.3 on the wrapper.

https://claude.ai/code/session_01BmWdT9tsj5KQApc8Zen2gp